### PR TITLE
Add kernel_name option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This is usually simple.
 For example in `mkdocs-material`
 (see [customization](https://squidfunk.github.io/mkdocs-material/customization/#overriding-template-blocks)),
 you can create a `main.html` file like this:
+
 ```
 {% extends "base.html" %}
 
@@ -101,6 +102,16 @@ You can tell the plugin to execute the notebook before converting, default is `F
 plugins:
   - mkdocs-jupyter:
       execute: True
+```
+
+### Kernel Name
+
+By default the plugin will use the kernel specified in the notebook to execute it. You can specify a custom kernel name to use for all the notebooks:
+
+```
+plugins:
+  - mkdocs-jupyter:
+      kernel_name: python3
 ```
 
 ### Download notebook link

--- a/mkdocs_jupyter/convert.py
+++ b/mkdocs_jupyter/convert.py
@@ -1,4 +1,5 @@
 import os
+import logging
 from copy import deepcopy
 
 from nbconvert.exporters import HTMLExporter, MarkdownExporter
@@ -11,6 +12,8 @@ from traitlets import Integer
 
 from mkdocs_jupyter.templates import GENERATED_MD
 from mkdocs_jupyter.utils import slugify
+
+logger = logging.getLogger('mkdocs.mkdocs-jupyter')
 
 
 # We monkeypatch nbconvert.filters.markdown_mistune.IPythonRenderer.header
@@ -85,8 +88,10 @@ def nb2md(nb_path):
     return body
 
 
-def nb2html(nb_path, start=0, end=None, execute=False):
+def nb2html(nb_path, start=0, end=None, execute=False, kernel_name=""):
     """Convert a notebook and return html"""
+
+    logger.info(f"Convert notebook {nb_path}")
 
     # Load the user's nbconvert configuration
     app = NbConvertApp()
@@ -101,7 +106,11 @@ def nb2html(nb_path, start=0, end=None, execute=False):
                 "highlight_class": ".highlight-ipynb",
             },
             "SubCell": {"enabled": True, "start": start, "end": end},
-            "ExecutePreprocessor": {"enabled": execute, "store_widget_state": True},
+            "ExecutePreprocessor": {
+                "enabled": execute,
+                "store_widget_state": True,
+                "kernel_name": kernel_name,
+            },
         }
     )
 

--- a/mkdocs_jupyter/plugin.py
+++ b/mkdocs_jupyter/plugin.py
@@ -33,6 +33,7 @@ class Plugin(mkdocs.plugins.BasePlugin):
     config_scheme = (
         ("execute", config_options.Type(bool, default=False)),
         ("include_source", config_options.Type(bool, default=False)),
+        ("kernel_name", config_options.Type(str, default=""))
     )
 
     def on_files(self, files, config):
@@ -49,9 +50,10 @@ class Plugin(mkdocs.plugins.BasePlugin):
     def on_pre_page(self, page, config, files):
         if str(page.file.abs_src_path).endswith(".ipynb"):
             exec_nb = self.config["execute"]
+            kernel_name = self.config["kernel_name"]
 
             def new_render(self, config, files):
-                body = convert.nb2html(page.file.abs_src_path, execute=exec_nb)
+                body = convert.nb2html(page.file.abs_src_path, execute=exec_nb, kernel_name=kernel_name)
                 self.content = body
                 self.toc = get_nb_toc(page.file.abs_src_path)
 


### PR DESCRIPTION
Fix https://github.com/danielfrg/mkdocs-jupyter/issues/19

It was quite simple to integrate it.

That being said I don't think I'll use that option since the main goal was to embed a custom ipywidget library called [nglview](https://github.com/nglviewer/nglview) but I can't make the JS widget to appear on the generated HTML. I tried tweaking the template without success.

Anyway, that kernel_name option should still be useful.