### PR TITLE
Fix accent problems in anchor link

### DIFF
--- a/mkdocs_jupyter/convert.py
+++ b/mkdocs_jupyter/convert.py
@@ -24,8 +24,8 @@ def add_anchor_lower_id(html, anchor_link_text="¶"):
     except Exception:
         # failed to parse, just return it unmodified
         return html
-    link = _convert_header_id(html2text(h))
-    h.set("id", slugify(link))
+    link = _convert_header_id(slugify(html2text(h)))
+    h.set("id", link)
     a = Element("a", {"class": "anchor-link", "href": "#" + link})
     try:
         # Test if the anchor link text is HTML (e.g. an image)


### PR DESCRIPTION
Accents (é, à) in anchor links were not rendered properly. I found that moving slugify fix the problem.  
I also think that the id and the ref should be the same, hence applying slugify to both.