### PR TITLE
set notebook encoding to utf-8

### DIFF
--- a/mkdocs_jupyter/nbconvert2.py
+++ b/mkdocs_jupyter/nbconvert2.py
@@ -97,7 +97,7 @@ def nb2html(
         content, resources = exporter.from_file(nb_file)
     else:
         try:
-            with open(nb_path, "r") as f:
+            with open(nb_path, "r", encoding="utf-8") as f:
                 nb_json = json.load(f)
                 kernel_lang = nb_json["metadata"]["kernelspec"]["language"]
         except KeyError:


### PR DESCRIPTION
When using notebooks with non-ASCII characters I would get an error (pasted below) about Unicode decoding.

In this pull request I simply set default encoding to "utf-8" when doing the json.load().

```
(base) PS C:\g\blog> mkdocs serve
INFO     -  Building documentation...
ERROR    -  Config value: 'plugins'. Error: Invalid Plugins configuration. Expected a list or dict.
Aborted with 1 Configuration Errors!
(base) PS C:\g\blog> mkdocs serve
INFO     -  Building documentation...
INFO     -  Cleaning site directory
INFO     -  Converting notebook (execute=False): C:\g\blog\docs\test.ipynb
ERROR    -  Error reading page 'test.ipynb': 'charmap' codec can't decode byte 0x90 in position 666: character maps to
            <undefined>
Traceback (most recent call last):
  File "c:\users\rpark\miniconda3\lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "c:\users\rpark\miniconda3\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Users\rpark\Miniconda3\Scripts\mkdocs.exe\__main__.py", line 7, in <module>
  File "c:\users\rpark\miniconda3\lib\site-packages\click\core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "c:\users\rpark\miniconda3\lib\site-packages\click\core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "c:\users\rpark\miniconda3\lib\site-packages\click\core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "c:\users\rpark\miniconda3\lib\site-packages\click\core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "c:\users\rpark\miniconda3\lib\site-packages\click\core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "c:\users\rpark\miniconda3\lib\site-packages\mkdocs\__main__.py", line 177, in serve_command
    serve.serve(dev_addr=dev_addr, livereload=livereload, **kwargs)
  File "c:\users\rpark\miniconda3\lib\site-packages\mkdocs\commands\serve.py", line 54, in serve
    config = builder()
  File "c:\users\rpark\miniconda3\lib\site-packages\mkdocs\commands\serve.py", line 49, in builder
    build(config, live_server=live_server, dirty=dirty)
  File "c:\users\rpark\miniconda3\lib\site-packages\mkdocs\commands\build.py", line 292, in build
    _populate_page(file.page, config, files, dirty)
  File "c:\users\rpark\miniconda3\lib\site-packages\mkdocs\commands\build.py", line 174, in _populate_page
    page.render(config, files)
  File "c:\users\rpark\miniconda3\lib\site-packages\mkdocs_jupyter\plugin.py", line 80, in new_render
    body = convert.nb2html(
  File "c:\users\rpark\miniconda3\lib\site-packages\mkdocs_jupyter\nbconvert2.py", line 101, in nb2html
    nb_json = json.load(f)
  File "c:\users\rpark\miniconda3\lib\json\__init__.py", line 293, in load
    return loads(fp.read(),
  File "c:\users\rpark\miniconda3\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 666: character maps to <undefined>
```