### PR TITLE
Update use of deprecated `defusedxml.cElementTree`

### DIFF
--- a/mkdocs_jupyter/convert.py
+++ b/mkdocs_jupyter/convert.py
@@ -13,7 +13,7 @@ from mkdocs_jupyter.utils import slugify
 def add_anchor_lower_id(html, anchor_link_text="¶"):
     from xml.etree.cElementTree import Element
 
-    from defusedxml import cElementTree as ElementTree
+    from defusedxml import ElementTree
     from nbconvert.filters.strings import _convert_header_id, html2text
 
     try:


### PR DESCRIPTION
See changelog entry for `0.7.0rc2` of https://pypi.org/project/defusedxml

This use was giving me deprecation warnings