### PR TITLE
Include widget states in `notebook.html.j2`

### DIFF
--- a/src/mkdocs_jupyter/templates/mkdocs_html/notebook.html.j2
+++ b/src/mkdocs_jupyter/templates/mkdocs_html/notebook.html.j2
@@ -139,6 +139,12 @@ mkdocs-material #}
 </div> <!-- jupyter-wrapper -->
 {% endblock body_footer %}
 
-{# CHANGE: Remove the footer - lab template outputs a full HTML page #}
+{# CHANGE: Remove the footer except widget states - lab template outputs a full HTML page #}
 {% block footer %}
+{% set mimetype = 'application/vnd.jupyter.widget-state+json'%}
+{% if mimetype in nb.metadata.get("widgets",{})%}
+<script type="{{ mimetype }}">
+{{ nb.metadata.widgets[mimetype] | json_dumps | escape_html_script }}
+</script>
+{% endif %}
 {% endblock footer %}


### PR DESCRIPTION
Thank you for working on the amazing project!

This pull request modifies the footer block in the `notebook.html.j2` template to include widget states in the exported HTML, which I found required to embed Jupyter Widgets in the HTML properly. (`include_requirejs` must be enabled as well.)

The code is just a port from the original `base.html.j2` of `nbconvert`: https://github.com/jupyter/nbconvert/blob/89de373448477b963729fe62a43bbc4bcffcdad9/share/templates/lab/base.html.j2#L323-L331
