### PR TITLE
chore: Add back support to py38

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         # os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.9, "3.10", 3.11]
+        python-version: [3.8, 3.9, "3.10", 3.11]
         node-version: [18]
 
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,13 +2,14 @@
 name = "mkdocs-jupyter"
 description = "Use Jupyter in mkdocs websites"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 license = { "text" = "Apache-2.0" }
 keywords = ["mkdocs", "jupyter", "jupyterlab", "notebooks", "documentation"]
 authors = [{ name = "Daniel Rodriguez", email = "daniel@danielfrg.com" }]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Programming Language :: Python",
+  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -41,7 +41,8 @@ idna==3.4
 importlib-metadata==6.8.0
 iniconfig==2.0.0
 ipykernel==6.24.0
-ipython==8.14.0
+ipython==8.12.0; python_version < '3.9'
+ipython==8.14.0; python_version >= '3.9'
 isoduration==20.11.0
 isort==5.12.0
 jedi==0.18.2

--- a/requirements.lock
+++ b/requirements.lock
@@ -27,7 +27,8 @@ ghp-import==2.1.0
 idna==3.4
 importlib-metadata==6.8.0
 ipykernel==6.24.0
-ipython==8.14.0
+ipython==8.12.0; python_version < '3.9'
+ipython==8.14.0; python_version >= '3.9'
 jedi==0.18.2
 jinja2==3.1.2
 jsonschema==4.17.3


### PR DESCRIPTION
This PR aims to add back the support python 3.8.

The estimated EoL for python 3.8 is `2024-10`, https://devguide.python.org/versions/