### PR TITLE
added custom_mathjax_url option

### DIFF
--- a/demo/mkdocs.yml
+++ b/demo/mkdocs.yml
@@ -54,7 +54,7 @@ plugins:
   - mkdocs-jupyter:
       execute: false
       include_requirejs: true
-
+      custom_mathjax_url: "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js?config=TeX-AMS_CHTML-full,Safe"
 extra:
   analytics:
     provider: google

--- a/src/mkdocs_jupyter/nbconvert2.py
+++ b/src/mkdocs_jupyter/nbconvert2.py
@@ -50,6 +50,7 @@ def nb2html(
     remove_tag_config: dict = {},
     highlight_extra_classes: str = "",
     include_requirejs: bool = False,
+    custom_mathjax_url: str = "",
 ):
     """
     Convert a notebook to HTML
@@ -125,6 +126,17 @@ def nb2html(
         theme=theme,
     )
 
+    if custom_mathjax_url != "":
+        exporter = HTMLExporter(
+        config=app.config,
+        template_file=template_file,
+        extra_template_paths=extra_template_paths,
+        preprocessors=preprocessors_,
+        filters=filters,
+        theme=theme,
+        mathjax_url=custom_mathjax_url,
+        )
+        
     _, extension = os.path.splitext(nb_path)
 
     if extension == ".py":

--- a/src/mkdocs_jupyter/plugin.py
+++ b/src/mkdocs_jupyter/plugin.py
@@ -49,6 +49,7 @@ class Plugin(mkdocs.plugins.BasePlugin):
         ("remove_tag_config", config_options.Type(dict, default={})),
         ("highlight_extra_classes", config_options.Type(str, default="")),
         ("include_requirejs", config_options.Type(bool, default=False)),
+        ("custom_mathjax_url", config_options.Type(str, default="")),
         ("toc_depth", config_options.Type(int, default=6)),
     )
     _supported_extensions = [".ipynb", ".py"]
@@ -91,6 +92,7 @@ class Plugin(mkdocs.plugins.BasePlugin):
             remove_tag_config = self.config["remove_tag_config"]
             highlight_extra_classes = self.config["highlight_extra_classes"]
             include_requirejs = self.config["include_requirejs"]
+            custom_mathjax_url = self.config["custom_mathjax_url"]
             toc_depth = self.config["toc_depth"]
 
             if (
@@ -118,6 +120,7 @@ class Plugin(mkdocs.plugins.BasePlugin):
                     remove_tag_config=remove_tag_config,
                     highlight_extra_classes=highlight_extra_classes,
                     include_requirejs=include_requirejs,
+                    custom_mathjax_url=custom_mathjax_url,
                 )
                 self.content = body
                 toc, title = get_nb_toc(page.file.abs_src_path, toc_depth)


### PR DESCRIPTION
Added the option to define a custom mathjax URL.  
Not sure if all the modifications are really necessary in the code, please check!
It also works with the privacy plugin of mkdocs-material.

Off topic: I'm not able to run the demo, some templates are missing in this repo. If I install mkdocs-jupyter via Pypi, the required template files are present.