### PR TITLE
Fix of possible issue with Table of Contents when leaving code under backquotes in markdown

### DIFF
--- a/src/mkdocs_jupyter/nbconvert2.py
+++ b/src/mkdocs_jupyter/nbconvert2.py
@@ -8,6 +8,7 @@ import io
 import json
 import logging
 import os
+import re
 
 import jupytext
 import mistune
@@ -199,7 +200,11 @@ def nb2md(nb_path, start=0, end=None, execute=False, kernel_name=""):
         body, resources = exporter.from_file(nb_file)
     else:
         body, resources = exporter.from_filename(nb_path)
-    return body
+
+    # Code cells can also be created using backquotes (text surrounded by up to three backquotes `)
+    # So it needs to be removed, also to not mess the table of contents (for more see "test_toc.py")
+    backquote_text_regex = r"`{1,3}[.\s\S]*?`{1,3}"
+    return re.sub(backquote_text_regex, "", body)
 
 
 def get_nbconvert_app(

--- a/src/mkdocs_jupyter/tests/mkdocs/docs/backquote_toc_test.ipynb
+++ b/src/mkdocs_jupyter/tests/mkdocs/docs/backquote_toc_test.ipynb
@@ -1,0 +1,94 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Multiple Backquote tests\n",
+    "<!-- # Comment Test -->\n",
+    "<!-- These comments must be ommited -->\n",
+    "\n",
+    "## Multiple Backquote test #1\n",
+    "test text 1 start\n",
+    "```cpp #include <iostream>```\n",
+    "test text 1 end\n",
+    "\n",
+    "## Multiple Backquote test #2\n",
+    "test text #2 start\n",
+    "```cpp\n",
+    "#include <iostream>```\n",
+    "test text #2 end\n",
+    "\n",
+    "## Multiple Backquote test #3\n",
+    "test text #3 start\n",
+    "```cpp\n",
+    "#include <iostream>\n",
+    "```\n",
+    "test text #3 end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This code node must be ommited during traversal"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Single Backquote tests\n",
+    "<!-- # Comment Test -->\n",
+    "<!-- These comments must be ommited -->\n",
+    "\n",
+    "## Single Backquote test #1\n",
+    "test text 1 start\n",
+    "`cpp #include <iostream>`\n",
+    "test text 1 end\n",
+    "\n",
+    "## Single Backquote test #2\n",
+    "test text #2 start\n",
+    "`cpp\n",
+    "#include <iostream>`\n",
+    "test text #2 end\n",
+    "\n",
+    "## Single Backquote test #3\n",
+    "test text #3 start\n",
+    "`cpp\n",
+    "#include <iostream>\n",
+    "`\n",
+    "test text #3 end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Header test 1\n",
+    "Header test 1 text\n",
+    "\n",
+    "# Header test 2\n",
+    "Header test 2 text\n",
+    "\n",
+    "### Header test 3\n",
+    "Header test 3 text"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/mkdocs_jupyter/tests/test_toc.py
+++ b/src/mkdocs_jupyter/tests/test_toc.py
@@ -1,0 +1,39 @@
+import os
+
+import pytest
+
+from mkdocs_jupyter import plugin
+from mkdocs.config import load_config
+from mkdocs.structure.toc import TableOfContents, AnchorLink
+
+
+@pytest.mark.parametrize(
+    "test_file_path,expected_anchor_count",
+    [  # make sure to update corresponding numbers if any file gets changed
+        ("./mkdocs/docs/fail.ipynb", 0),
+        ("./mkdocs/docs/backquote_toc_test.ipynb", 11),
+        ("./mkdocs/docs/demo.ipynb", 16),
+        ("./mkdocs/docs/ruby.ipynb", 11),
+        ("./mkdocs/docs/variational-inference.ipynb", 23),
+    ],
+)
+def test_anchors_count(test_file_path, expected_anchor_count) -> None:
+    this_dir = os.path.dirname(os.path.realpath(__file__))
+    test_file_dir = os.path.join(this_dir, test_file_path)
+
+    config_file = os.path.join(this_dir, "mkdocs/base-with-nbs.yml")
+    toc_depth = load_config(config_file)["plugins"]["mkdocs-jupyter"].config["toc_depth"]
+
+    toc: TableOfContents = plugin.get_nb_toc(test_file_dir, toc_depth)[0]
+
+    anchor_count = 0
+    traverse_stack: list[AnchorLink] = list(toc)
+    while traverse_stack:
+        anchor = traverse_stack[0]
+
+        # print("\t" * (anchor.level - 1) + f'{anchor.level} | {anchor.title}')
+        anchor_count += 1
+        traverse_stack.remove(anchor)
+        traverse_stack = anchor.children + traverse_stack
+
+    assert anchor_count == expected_anchor_count


### PR DESCRIPTION
I recently started to use "mkdocs" with "mkdocs-jupyter" package for my notebooks and stumbled across an issue, when I used C++ code samples under backquotes.

Basically if there's a line starting with number sign (#) within 1-3 backquotes (`), which is allowed in markdown, table of contents stops before first encounter of this.

For example, before changes, this IPython Notebook:
![image](https://github.com/danielfrg/mkdocs-jupyter/assets/24298192/27f047c9-a5e7-4e43-8e98-683cbafda725)

resulting in this page (look at the table of contents on the right)
![image](https://github.com/danielfrg/mkdocs-jupyter/assets/24298192/81d5268e-573a-499d-b6d9-2f4ae582d194)

After changes:
![image](https://github.com/danielfrg/mkdocs-jupyter/assets/24298192/85117689-796a-4586-aafc-5791019fb337)

- I also added tests (see [test_toc.py](src/mkdocs_jupyter/tests/test_toc.py))

Sadly I couldn't successfully run the other tests (regardless of any changes), but I set up project _via rye_ as described in [CONTRIBUTING.md](https://github.com/danielfrg/mkdocs-jupyter/blob/main/CONTRIBUTING.md)