### PR TITLE
Only copy source files if they are converted by the plugin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,7 @@ jobs:
           file: ./coverage.xml
 
       - name: Upload test results to GitHub
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: test-results-py${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # mkdocs-jupyter Change Log
 
+## 0.25.1
+
+- Fix issue which caused unrelated source files from being copied into the output directory.
+- Replace print statements with logging.
+
 ## 0.24.3
 
 - Fix theme selection

--- a/src/mkdocs_jupyter/plugin.py
+++ b/src/mkdocs_jupyter/plugin.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pathlib
 
@@ -11,6 +12,8 @@ from mkdocs.structure.pages import Page
 from mkdocs.structure.toc import get_toc
 
 from . import convert
+
+logger = logging.getLogger("mkdocs.plugins.mkdocs_jupyter")
 
 
 class NotebookFile(File):
@@ -160,7 +163,7 @@ class Plugin(mkdocs.plugins.BasePlugin):
 
             os.makedirs(nb_target_dir, exist_ok=True)
             copyfile(nb_source, nb_target)
-            print(f"Copied jupyter file: {nb_source} to {nb_target}")
+            logger.info("Copied jupyter file: %s to %s", nb_source, nb_target)
 
         # Include data files
         data_files = self.config["data_files"].get(page.file.src_path, [])
@@ -175,7 +178,7 @@ class Plugin(mkdocs.plugins.BasePlugin):
 
                 os.makedirs(data_target_dir, exist_ok=True)
                 copyfile(data_source, data_target)
-            print(page.data_files)
+            logger.info("Copied data files: %s to %s", data_files, data_target_dir)
 
 
 def _get_markdown_toc(markdown_source, toc_depth):

--- a/src/mkdocs_jupyter/plugin.py
+++ b/src/mkdocs_jupyter/plugin.py
@@ -153,7 +153,7 @@ class Plugin(mkdocs.plugins.BasePlugin):
 
     def on_post_page(self, output_content, page, config):
         # Include source
-        if self.config["include_source"]:
+        if self.config["include_source"] and self.should_include(page.file):
             from shutil import copyfile
 
             nb_source = page.file.abs_src_path


### PR DESCRIPTION
This PR fixes the following issue(s):

Instead of blindly copying all source files, including plain markdown files, only copy files converted by the plugin. This prevents all plain markdown files from being copied into the build output.

I also replaced the print statements with logging statements. Otherwise, the print can easily mess up automated scripts.
