### PR TITLE
Check ignore patterns before reading files

### DIFF
--- a/src/mkdocs_jupyter/tests/test_pkg.py
+++ b/src/mkdocs_jupyter/tests/test_pkg.py
@@ -1,8 +1,11 @@
 import os
+from unittest.mock import patch
 
 import pytest
+from mkdocs.structure.files import File
 
 import mkdocs_jupyter
+from mkdocs_jupyter import plugin
 from mkdocs_jupyter.config import settings
 
 pytestmark = [pytest.mark.pkg]
@@ -28,3 +31,15 @@ def test_assets_included():
     mkdocs_md = os.path.join(settings.templates_dir, "mkdocs_md")
     assert os.path.exists(os.path.join(mkdocs_md, "conf.json"))
     assert os.path.exists(os.path.join(mkdocs_md, "md-no-codecell.md.j2"))
+
+
+def test_markdown_ignored_without_parsing() -> None:
+    """
+    Test that ignored Markdown files are not parsed.
+    """
+    plug = plugin.Plugin()
+    plug.config["ignore"] = ["**/*.md"]
+    dummy_md_file = File("file.md", "docs", "site", False)
+    with patch.object(plugin.jupytext, "read") as mock_read:
+        assert plug.should_include(dummy_md_file) is False
+        assert mock_read.call_count == 0


### PR DESCRIPTION
Closes #239 by changing the order of checks in `should_include` to return early when files match ignored patterns. For Markdown files, this can avoid unnecessary reads and potential warnings from `jupytext`.

I wasn't sure the best place to put the test, so I just included it alongside some other API tests for now. Happy to move that elsewhere.