### PR TITLE
html escape source text for clipboard copy

### DIFF
--- a/src/mkdocs_jupyter/nbconvert2.py
+++ b/src/mkdocs_jupyter/nbconvert2.py
@@ -303,7 +303,8 @@ def mk_custom_highlight_code(extra_css_classes=""):
         formatter = HtmlFormatter(cssclass=classes)
         output = _pygments_highlight(source, formatter, language, metadata)
 
-        clipboard_copy_txt = f"""<div id="cell-{cell_id}" class="clipboard-copy-txt">{source}</div>
+        escaped = mistune.escape(source)
+        clipboard_copy_txt = f"""<div id="cell-{cell_id}" class="clipboard-copy-txt">{escaped}</div>
         """
         return output + clipboard_copy_txt
 


### PR DESCRIPTION
Hi, thanks for maintaining this!

We noticed that some of the "copy" buttons in our converted notebooks ([example](https://vespa-engine.github.io/pyvespa/examples/video_search_twelvelabs_cloud.html)) failed to include parts of the code that are contained in angle brackets < >:

when copying
`type="array<float>",`
what I get in my clipboard is just
`type="array",`
 
HTML escaping the source fixes this.