### PR TITLE
Allow `ipykernel>6,<8`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "mkdocs-material>9.0.0",
     "jupytext>1.13.8,<2",
     "Pygments>2.12.0",
-    "ipykernel<7.0.0,>6.0.0",
+    "ipykernel>6.0.0,<8",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Allow using with the latest version of `ipykernel`
https://github.com/ipython/ipykernel/releases
